### PR TITLE
AGT-498: support report method parameter

### DIFF
--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -175,7 +175,7 @@ function bidWon(args, isReportExternal) {
     if (method === 'POST') {
       ajax(url, undefined, payload, {method, contentType: 'application/x-www-form-urlencoded'});
     } else {
-      ajax(url, undefined, null, {method: 'GET'});
+      ajax(url, undefined, null, {method});
     }
     logInfo('IIQ ANALYTICS -> BID WON');
     return true;

--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -173,7 +173,7 @@ function bidWon(args, isReportExternal) {
   if ((isReportExternal && iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled) || (!isReportExternal && !iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled)) {
     const { url, method, payload } = constructFullUrl(preparePayload(args, true));
     if (method === 'POST') {
-      ajax(url, undefined, payload, {method: 'POST', contentType: 'application/x-www-form-urlencoded'});
+      ajax(url, undefined, payload, {method, contentType: 'application/x-www-form-urlencoded'});
     } else {
       ajax(url, undefined, null, {method: 'GET'});
     }

--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -105,7 +105,7 @@ const {
   BID_REQUESTED
 } = EVENTS;
 
-function initLsValues() {
+function initAdapterConfig() {
   if (iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized) return;
   let iiqConfig = getIntentIqConfig()
 
@@ -156,7 +156,7 @@ function initReadLsIds() {
 
 function bidWon(args, isReportExternal) {
   if (!iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized) {
-    initLsValues();
+    initAdapterConfig();
   }
 
   if (isNaN(iiqAnalyticsAnalyticsAdapter.initOptions.partner) || iiqAnalyticsAnalyticsAdapter.initOptions.partner == -1) return;
@@ -357,10 +357,9 @@ function constructFullUrl(data) {
   url = appendVrrefAndFui(url, iiqAnalyticsAnalyticsAdapter.initOptions.domainName);
   if (reportMethod === 'POST') {
     return { url, method: 'POST', payload: JSON.stringify(report) };
-  } else {
-    url += '&payload=' + encodeURIComponent(JSON.stringify(report));
-    return { url, method: 'GET' };
   }
+  url += '&payload=' + encodeURIComponent(JSON.stringify(report));
+  return { url, method: 'GET' };
 }
 
 iiqAnalyticsAnalyticsAdapter.originEnableAnalytics = iiqAnalyticsAnalyticsAdapter.enableAnalytics;

--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -11,7 +11,7 @@ import {appendVrrefAndFui, getReferrer} from '../libraries/intentIqUtils/getReff
 import {getCmpData} from '../libraries/intentIqUtils/getCmpData.js'
 import {CLIENT_HINTS_KEY, FIRST_PARTY_KEY, VERSION} from '../libraries/intentIqConstants/intentIqConstants.js';
 import {readData, defineStorageType} from '../libraries/intentIqUtils/storageUtils.js';
-import {reportingServerAddress} from '../libraries/intentIqUtils/IntentIqConfig.js';
+import {reportingServerAddress} from '../libraries/intentIqUtils/intentIqConfig.js';
 
 const MODULE_NAME = 'iiqAnalytics'
 const analyticsType = 'endpoint';
@@ -82,7 +82,8 @@ let iiqAnalyticsAnalyticsAdapter = Object.assign(adapter({url: DEFAULT_URL, anal
     eidl: null,
     lsIdsInitialized: false,
     manualWinReportEnabled: false,
-    domainName: null
+    domainName: null,
+    reportMethod: null
   },
   track({eventType, args}) {
     switch (eventType) {
@@ -117,9 +118,11 @@ function initLsValues() {
       typeof iiqConfig.params?.browserBlackList === 'string' ? iiqConfig.params.browserBlackList.toLowerCase() : '';
     iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled = iiqConfig.params?.manualWinReportEnabled || false;
     iiqAnalyticsAnalyticsAdapter.initOptions.domainName = iiqConfig.params?.domainName || '';
+    iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod = parseReportingMethod(iiqConfig.params?.reportMethod);
   } else {
     iiqAnalyticsAnalyticsAdapter.initOptions.lsValueInitialized = false;
     iiqAnalyticsAnalyticsAdapter.initOptions.partner = -1;
+    iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod = 'GET';
   }
 }
 
@@ -168,11 +171,30 @@ function bidWon(args, isReportExternal) {
     initReadLsIds();
   }
   if ((isReportExternal && iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled) || (!isReportExternal && !iiqAnalyticsAnalyticsAdapter.initOptions.manualWinReportEnabled)) {
-    ajax(constructFullUrl(preparePayload(args, true)), undefined, null, {method: 'GET'});
-    logInfo('IIQ ANALYTICS -> BID WON')
+    const { url, method, payload } = constructFullUrl(preparePayload(args, true));
+    if (method === 'POST') {
+      ajax(url, undefined, payload, {method: 'POST', contentType: 'application/x-www-form-urlencoded'});
+    } else {
+      ajax(url, undefined, null, {method: 'GET'});
+    }
+    logInfo('IIQ ANALYTICS -> BID WON');
     return true;
   }
   return false;
+}
+
+function parseReportingMethod(reportMethod) {
+  if (typeof reportMethod === 'string') {
+      switch (reportMethod.toUpperCase()) {
+          case 'GET':
+              return 'GET';
+          case 'POST':
+              return 'POST';
+          default:
+              return 'GET';
+      }
+    }
+  return 'GET';
 }
 
 function defineGlobalVariableName() {
@@ -311,6 +333,7 @@ function getDefaultDataObject() {
 
 function constructFullUrl(data) {
   let report = [];
+  const reportMethod = iiqAnalyticsAnalyticsAdapter.initOptions.reportMethod;
   data = btoa(JSON.stringify(data));
   report.push(data);
 
@@ -324,7 +347,6 @@ function constructFullUrl(data) {
     '&agid=' + REPORTER_ID +
     '&jsver=' + VERSION +
     '&source=pbjs' +
-    '&payload=' + JSON.stringify(report) +
     '&uh=' + encodeURIComponent(iiqAnalyticsAnalyticsAdapter.initOptions.clientsHints) +
     (cmpData.uspString ? '&us_privacy=' + encodeURIComponent(cmpData.uspString) : '') +
     (cmpData.gppString ? '&gpp=' + encodeURIComponent(cmpData.gppString) : '') +
@@ -333,7 +355,12 @@ function constructFullUrl(data) {
       : '&gdpr=0');
 
   url = appendVrrefAndFui(url, iiqAnalyticsAnalyticsAdapter.initOptions.domainName);
-  return url;
+  if (reportMethod === 'POST') {
+    return { url, method: 'POST', payload: JSON.stringify(report) };
+  } else {
+    url += '&payload=' + encodeURIComponent(JSON.stringify(report));
+    return { url, method: 'GET' };
+  }
 }
 
 iiqAnalyticsAnalyticsAdapter.originEnableAnalytics = iiqAnalyticsAnalyticsAdapter.enableAnalytics;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
