### PR TITLE
AGT-499: Support partnerClientIdType and partnerClientId

### DIFF
--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -130,7 +130,7 @@ function appendFirstPartyData (url, firstPartyData, partnerData) {
 
 function verifyIdType(value) {
   if (value === 0 || value === 1 || value === 3 || value === 4) return value;
-  else return -1;
+  return -1;
 }
 
 function appendPartnersFirstParty (url, configParams) {

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -489,7 +489,6 @@ export const intentIqIdSubmodule = {
 
     // use protocol relative urls for http or https
     let url = `${iiqServerAddress(configParams, gdprDetected)}/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=${configParams.partner}&pt=17&dpn=1`;
-    // url += configParams.pcid ? '&pcid=' + encodeURIComponent(configParams.pcid) : '';
     url += configParams.pai ? '&pai=' + encodeURIComponent(configParams.pai) : '';
     url = appendFirstPartyData(url, firstPartyData, partnerData);
     url = appendPartnersFirstParty(url, configParams);

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -128,6 +128,23 @@ function appendFirstPartyData (url, firstPartyData, partnerData) {
   return url
 }
 
+function verifyIdType(value) {
+  if (value === 0 || value === 1 || value === 3 || value === 4) return value;
+  else return -1;
+}
+
+function appendPartnersFirstParty (url, configParams) {
+  let partnerClientId = typeof configParams.partnerClientId === 'string' ? encodeURIComponent(configParams.partnerClientId) : '';
+  let partnerClientIdType = typeof configParams.partnerClientIdType === 'number' ? verifyIdType(configParams.partnerClientIdType) : -1;
+
+  if (partnerClientIdType === -1) return url;
+  if (partnerClientId !== '') {
+      url = url + '&pcid=' + partnerClientId;
+      url = url + '&idtype=' + partnerClientIdType;
+  }
+  return url;
+}
+
 function appendCMPData (url, cmpData) {
   url += cmpData.uspString ? '&us_privacy=' + encodeURIComponent(cmpData.uspString) : '';
   url += cmpData.gppString ? '&gpp=' + encodeURIComponent(cmpData.gppString) : '';
@@ -176,6 +193,7 @@ export function createPixelUrl(firstPartyData, clientHints, configParams, partne
   url += '/profiles_engine/ProfilesEngineServlet?at=20&mi=10&secure=1'
   url += '&dpi=' + configParams.partner;
   url = appendFirstPartyData(url, firstPartyData, partnerData);
+  url = appendPartnersFirstParty(url, configParams);
   url = addUniquenessToUrl(url);
   url += partnerData?.clientType ? '&idtype=' + partnerData.clientType : '';
   if (deviceInfo) url = appendDeviceInfoToUrl(url, deviceInfo)
@@ -471,9 +489,10 @@ export const intentIqIdSubmodule = {
 
     // use protocol relative urls for http or https
     let url = `${iiqServerAddress(configParams, gdprDetected)}/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=${configParams.partner}&pt=17&dpn=1`;
-    url += configParams.pcid ? '&pcid=' + encodeURIComponent(configParams.pcid) : '';
+    // url += configParams.pcid ? '&pcid=' + encodeURIComponent(configParams.pcid) : '';
     url += configParams.pai ? '&pai=' + encodeURIComponent(configParams.pai) : '';
     url = appendFirstPartyData(url, firstPartyData, partnerData);
+    url = appendPartnersFirstParty(url, configParams);
     url += (partnerData.cttl) ? '&cttl=' + encodeURIComponent(partnerData.cttl) : '';
     url += (partnerData.rrtt) ? '&rrtt=' + encodeURIComponent(partnerData.rrtt) : '';
     url = appendCMPData(url, cmpData);

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -887,6 +887,90 @@ describe('IntentIQ tests', function () {
     expect(request.url).to.not.include('&fbp=');
   });
 
+  it('should send pcid and idtype in AT=20 if it provided in config', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 0;
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).to.include(`&pcid=${encodeURIComponent(partnerClientId)}`);
+    expect(request.url).to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send pcid and idtype in AT=20 if partnerClientId is NOT a string', function () {
+    let partnerClientId = 123;
+    let partnerClientIdType = 0;
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).not.to.include(`&pcid=`);
+    expect(request.url).not.to.include(`&idtype=`);
+  });
+
+  it('should NOT send pcid and idtype in AT=20 if partnerClientIdType is NOT a number', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 'wrong';
+    const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', partnerClientId, partnerClientIdType} };
+
+    intentIqIdSubmodule.getId(configParams);
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=20');
+    expect(request.url).not.to.include(`&pcid=`);
+    expect(request.url).not.to.include(`&idtype=`);
+  });
+
+  it('should send partnerClientId and partnerClientIdType in AT=39 if it provided in config', function () {
+    let partnerClientId = 'partnerClientId 123';
+    let partnerClientIdType = 0;
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).to.include(`&pcid=${encodeURIComponent(partnerClientId)}`);
+    expect(request.url).to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send partnerClientId and partnerClientIdType in AT=39 if partnerClientId is not a string', function () {
+    let partnerClientId = 123;
+    let partnerClientIdType = 0;
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include(`&pcid=${partnerClientId}`);
+    expect(request.url).not.to.include(`&idtype=${partnerClientIdType}`);
+  });
+
+  it('should NOT send partnerClientId and partnerClientIdType in AT=39 if partnerClientIdType is not a number', function () {
+    let partnerClientId = 'partnerClientId-123';
+    let partnerClientIdType = 'wrong';
+    let callBackSpy = sinon.spy();
+    const configParams = { params: {...allConfigParams.params, partnerClientId, partnerClientIdType} };
+    let submoduleCallback = intentIqIdSubmodule.getId(configParams).callback;
+    submoduleCallback(callBackSpy);
+
+    let request = server.requests[0];
+
+    expect(request.url).to.include('?at=39')
+    expect(request.url).not.to.include(`&pcid=${partnerClientId}`);
+    expect(request.url).not.to.include(`&idtype=${partnerClientIdType}`);
+  });
+
   it('should NOT send sourceMetaData in AT=20 if sourceMetaDataExternal provided', function () {
     const configParams = { params: {...allConfigParams.params, browserBlackList: 'chrome', sourceMetaDataExternal: 123} };
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
Support partnerClientIdType and partnerClientId 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
